### PR TITLE
feat: add CI builds + attestation

### DIFF
--- a/.github/workflows/cloud-hello.yml
+++ b/.github/workflows/cloud-hello.yml
@@ -1,0 +1,98 @@
+name: cloud-hello
+
+on:
+  pull_request:
+    paths:
+      - 'cloud-hello/**'
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - cloud-hello-v*
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo clippy --no-deps
+        working-directory: cloud-hello
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          rustup target add wasm32-wasi
+          cargo build --target wasm32-wasi
+        working-directory: cloud-hello
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/cloud-hello-v')
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract tag context
+        id: ctx
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_REF#refs/tags/cloud-hello-v}" >> "$GITHUB_OUTPUT"
+
+      - run: rustup target add wasm32-wasi
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wash-cli@0.27
+
+      - name: Build and push
+        run: |
+          wash build
+        working-directory: cloud-hello
+
+      # Used later in the build process to push provenance info
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: imjasonh/setup-crane@v0.1
+
+      - name: Push
+        id: push
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          WASH_ISSUER_KEY: ${{ secrets.COSMONIC_LABS_SIGNING_ACCOUNT}}
+          WASH_SUBJECT_KEY: ${{ secrets.CLOUD_HELLO_COMPONENT_KEY}}
+        run: |
+          if [ -z "$WASH_ISSUER_KEY" ]; then
+            echo "WASH_ISSUER_KEY is not set"
+            exit 1
+          fi
+          wash push ${{env.REGISTRY}}/${{env.REPOSITORY}}/cloud-hello:$GITHUB_SHA build/cloud_hello_s.wasm
+          wash push ${{env.REGISTRY}}/${{env.REPOSITORY}}/cloud-hello:$(git rev-parse --short HEAD) build/cloud_hello_s.wasm
+          #wash push ${{env.REGISTRY}}/${{env.REPOSITORY}}/cloud-hello:${{steps.ctx.outputs.version}} build/cloud_hello_s.wasm
+          digest=$(crane digest ${{env.REGISTRY}}/${{env.REPOSITORY}}/cloud-hello:$GITHUB_SHA)
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+        shell: bash
+        working-directory: cloud-hello
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{env.REGISTRY}}/${{env.REPOSITORY}}/cloud-hello
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/fly-io-metadata.yml
+++ b/.github/workflows/fly-io-metadata.yml
@@ -1,0 +1,39 @@
+name: fly-io-metadata
+
+on:
+  pull_request:
+    paths:
+      - 'fly-io-metadata/**'
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - fly-io-metadata-v*
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo clippy --no-deps
+        working-directory: fly-io-metadata
+
+  build:
+    needs:
+      - lint
+    permissions:
+      packages: write
+      id-token: write
+      attestations: write
+      contents: read
+    uses: ./.github/workflows/provider.yml
+    with:
+      name: fly-io-metadata
+    secrets:
+      issuer: ${{secrets.COSMONIC_LABS_SIGNING_ACCOUNT}}
+      subject: ${{secrets.FLY_IO_PROVIDER_KEY}}

--- a/.github/workflows/kind-metadata.yml
+++ b/.github/workflows/kind-metadata.yml
@@ -1,0 +1,39 @@
+name: kind-metadata
+
+on:
+  pull_request:
+    paths:
+      - 'kind-metadata/**'
+  merge_group:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - kind-metadata-v*
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo clippy --no-deps
+        working-directory: kind-metadata
+
+  build:
+    needs:
+      - lint
+    permissions:
+      packages: write
+      id-token: write
+      attestations: write
+      contents: read
+    uses: ./.github/workflows/provider.yml
+    with:
+      name: kind-metadata
+    secrets:
+      issuer: ${{secrets.COSMONIC_LABS_SIGNING_ACCOUNT}}
+      subject: ${{secrets.FLY_IO_PROVIDER_KEY}}

--- a/.github/workflows/provider.yml
+++ b/.github/workflows/provider.yml
@@ -1,0 +1,131 @@
+name: Build and release a provider
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: Provider name
+        required: true
+        type: string
+    secrets:
+      subject:
+        required: true
+        description: Capability provider issuer subject key
+      issuer:
+        required: true
+        description: Capability provider issuer key
+env:
+  REGISTRY: ghcr.io
+  REPOSITORY: ${{ github.repository }}
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch: ["x86_64", "aarch64"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: goto-bus-stop/setup-zig@v2
+
+      - name: Add musl targets
+        run: |
+          rustup target add ${{ matrix.arch }}-unknown-linux-musl
+
+      - name: Install cargo-zigbuild
+        run: |
+          cargo install cargo-zigbuild
+
+      - name: Build
+        run: |
+          cargo zigbuild --release --target ${{matrix.arch}}-unknown-linux-musl
+          name=$(echo ${{inputs.name}} | tr '-' '_')
+          mv target/${{matrix.arch}}-unknown-linux-musl/release/$name ${{inputs.name}}
+        working-directory: ${{inputs.name}}
+
+      - name: Store artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{inputs.name}}-${{matrix.arch}}
+          path: ${{inputs.name}}/${{inputs.name}}
+  release:
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/${{inputs.name}}-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract tag context
+        id: ctx
+        run: |
+          sha_short=$(git rev-parse --short HEAD)
+          echo "owner=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=${sha_short}" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_REF#refs/tags/${{inputs.name}}v}" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$(echo ${{inputs.name}} | tr '- "')" >> "$GITHUB_OUTPUT"
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wash-cli@0.28.0
+
+      # Used later in the build process to push provenance info
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: imjasonh/setup-crane@v0.1
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Fix permissions and architectures
+        run: |
+          tree artifacts
+          mv artifacts/${{inputs.name}}-x86_64/${{inputs.name}} ${{inputs.name}}-x86_64
+          mv artifacts/${{inputs.name}}-aarch64/${{inputs.name}} ${{inputs.name}}-aarch64
+          chmod +x ${{inputs.name}}-*
+
+      - name: Push
+        env:
+          WASH_REG_USER: ${{ github.repository_owner }}
+          WASH_REG_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          WASH_ISSUER_KEY: ${{ secrets.subject}}
+          WASH_SUBJECT_KEY: ${{ secrets.issuer}}
+        run: |
+          if [ -z $WASH_SUBJECT_KEY ]; then
+            echo "WASH_SUBJECT_KEY is required"
+            exit 1
+          fi
+
+          if [ -z $WASH_ISSUER_KEY ]; then
+            echo "WASH_ISSUER_KEY is required"
+            exit 1
+          fi
+
+          wash par create \
+          --binary "${{ inputs.name }}-x86_64" \
+          --compress \
+          --destination "${{ inputs.name }}.par.gz" \
+          --name "${{ inputs.name }}-provider" \
+          --vendor cosmonic-labs \
+          --version ${{ steps.ctx.outputs.version }}
+
+          wash par insert --arch aarch64-linux --binary "${{inputs.name }}-aarch64" "${{ inputs.name }}.par.gz"
+
+          wash push ${{env.REGISTRY}}/${{env.REPOSITORY}}/${{inputs.name}}:$GITHUB_SHA ${{inputs.name}}.par.gz
+          wash push ${{env.REGISTRY}}/${{env.REPOSITORY}}/${{inputs.name}}:$(git rev-parse --short HEAD) ${{inputs.name}}.par.gz
+          #wash push ${{env.REGISTRY}}/${{env.REPOSITORY}}/${{inputs.name}}:${{steps.ctx.outputs.version}} ${{inputs.name}}.par.gz
+
+      - name: Get digest
+        id: digest
+        run: |
+          digest=$(crane digest ${{env.REGISTRY}}/${{env.REPOSITORY}}/${{inputs.name}}:$GITHUB_SHA)
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{env.REGISTRY}}/${{env.REPOSITORY}}/${{inputs.name}}
+          subject-digest: ${{ steps.digest.outputs.digest }}
+          push-to-registry: true

--- a/cloud-hello/src/lib.rs
+++ b/cloud-hello/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::missing_safety_doc)]
 wit_bindgen::generate!();
 
 use axum::{
@@ -18,7 +19,7 @@ use std::{collections::BTreeMap, io::Write};
 use tower_service::Service;
 use wasi::http::types::*;
 use wasi::logging::logging::*;
-use wrpc::keyvalue::{atomics, batch, store};
+use wrpc::keyvalue::{atomics, store};
 
 mod helpers;
 use helpers::*;


### PR DESCRIPTION
Add build pipelines for releasing the component and providers in this repository to ghcr. This also uses Github's new attestation support for generating build provenance as the final step of the release process.